### PR TITLE
wrong form of get_drug_purchases in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-laitetaan kordissimi# fganalysis R Package
+# fganalysis R Package
 
 ## Overview
 


### PR DESCRIPTION
Example uses conn$pheno instead of conn, which is how it used to be.

Also look at #28 for making get_drug_purchases and get_lab_measurements to use the same types of input parameters