### PR TITLE
Anthrop measures file path updated to fixed version for R14

### DIFF
--- a/inst/config/db_config_sb_r14.json
+++ b/inst/config/db_config_sb_r14.json
@@ -26,7 +26,7 @@
         "colclasses": {"VNR": "character"}
     },
     "long_anthropometric": {
-        "path": "/finngen/shared_nfs/Resources/fganalysis/R14/finngen_R14_hilmo_avohilmo_extended_1.0_dedup_fixbp.parquet",
+        "path": "/finngen/shared_nfs/Resources/fganalysis/R14/finngen_R14_hilmo_avohilmo_extended_2.0_dedup_fixbp.parquet",
         "type": "parquet"
     },
         "drug_events": {


### PR DESCRIPTION
v1.0 of Hilmo-Avohilmo file for R14 was missing many weight measures. New file has been released so I have updated the sandbox config file to point to the newer version (v2.0).